### PR TITLE
Issues with index with column that have low cardinality

### DIFF
--- a/src/Cli/Command/RunCommand.php
+++ b/src/Cli/Command/RunCommand.php
@@ -210,6 +210,10 @@ class RunCommand extends AbstractDatabaseCommand
         $password = $this->getDatabasePassword($input, $output);
 
         $schemas = (array)$input->getArgument('schema');
+        if (!count($schemas)) {
+            return Command::FAILURE;
+        }
+
         $factory = $this->getFactory($input, $schemas[0], $password);
         $this->runChecksAgainstSchema($input, $schemas, $factory, $output);
         $factory->getConnection()->close();

--- a/src/Engine/Check/Index/LowCardinality.php
+++ b/src/Engine/Check/Index/LowCardinality.php
@@ -44,11 +44,11 @@ class LowCardinality implements Check
         $status = Report::STATUS_OK;
         if ($ratio >= 10_000) {
             $status = Report::STATUS_WARNING;
-            $messages[] = "This seems particularly high and will cause large result sets for queries using it.";
+            $messages[] = "This seems particularly high and will cause longer querying times or the index being ignored (wasted space/processing).";
         }
         else if ($ratio >= 1_000) {
             $status = Report::STATUS_CONCERN;
-            $messages[] = "This seems high and may cause large result sets for queries using it.";
+            $messages[] = "This seems high and may cause longer querying times or the index being ignored (wasted space/processing).";
         }
 
         return new Report(

--- a/src/Engine/Check/Index/LowCardinality.php
+++ b/src/Engine/Check/Index/LowCardinality.php
@@ -18,7 +18,7 @@ class LowCardinality implements Check
     public function run($entity): ?Report
     {
         // If the index is unique, then the cardinality is as high as it can be
-        if ($entity->is_unqiue) {
+        if ($entity->isUnique()) {
             return new Report(
                 $this,
                 $entity,
@@ -31,8 +31,8 @@ class LowCardinality implements Check
 
         // Identify the cardinality as a ratio of the size of the table
         // Cardinality in older version of MySQL aren't distinct per column
-        $table_size = $entity->table->information_schema->table_rows;
-        $cardinality = $entity->columns[0]->cardinality;
+        $table_size = $entity->getTable()->information_schema->table_rows;
+        $cardinality = $entity->getColumns()[0]->cardinality;
 
         $ratio = $table_size / $cardinality;
 
@@ -41,11 +41,12 @@ class LowCardinality implements Check
         $messages = [
             "The ratio of cardinality for this index is $ratio."
         ];
-        if ($ratio > 10_000) {
+        $status = Report::STATUS_OK;
+        if ($ratio >= 10_000) {
             $status = Report::STATUS_WARNING;
             $messages[] = "This seems particularly high and will cause large result sets for queries using it.";
         }
-        if ($ratio > 1_000) {
+        else if ($ratio >= 1_000) {
             $status = Report::STATUS_CONCERN;
             $messages[] = "This seems high and may cause large result sets for queries using it.";
         }

--- a/src/Engine/Check/Index/LowCardinality.php
+++ b/src/Engine/Check/Index/LowCardinality.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cadfael\Engine\Check\Index;
+
+use Cadfael\Engine\Check;
+use Cadfael\Engine\Entity\Index;
+use Cadfael\Engine\Report;
+
+class LowCardinality implements Check
+{
+    public function supports($entity): bool
+    {
+        return $entity instanceof Index;
+    }
+
+    public function run($entity): ?Report
+    {
+        // If the index is unique, then the cardinality is as high as it can be
+        if ($entity->is_unqiue) {
+            return new Report(
+                $this,
+                $entity,
+                Report::STATUS_OK
+            );
+        }
+
+        // If the index is also a primary key, we can skip it
+        // However we currently don't build those, so no worries :)
+
+        // Identify the cardinality as a ratio of the size of the table
+        // Cardinality in older version of MySQL aren't distinct per column
+        $table_size = $entity->table->information_schema->table_rows;
+        $cardinality = $entity->columns[0]->cardinality;
+
+        $ratio = $table_size / $cardinality;
+
+        // The closer to 1 this value is, the more unique it is.
+        // The larger it is, the less unique the results are.
+        $messages = [
+            "The ratio of cardinality for this index is $ratio."
+        ];
+        if ($ratio > 10_000) {
+            $status = Report::STATUS_WARNING;
+            $messages[] = "This seems particularly high and will cause large result sets for queries using it.";
+        }
+        if ($ratio > 1_000) {
+            $status = Report::STATUS_CONCERN;
+            $messages[] = "This seems high and may cause large result sets for queries using it.";
+        }
+
+        return new Report(
+            $this,
+            $entity,
+            $status,
+            $messages
+        );
+    }
+}

--- a/src/Engine/Entity/Column.php
+++ b/src/Engine/Entity/Column.php
@@ -14,6 +14,7 @@ class Column implements Entity
     protected string $name;
     protected Table $table;
     public InformationSchema $information_schema;
+    public int $cardinality;
 
     private function __construct()
     {
@@ -42,14 +43,14 @@ class Column implements Entity
         $this->table = $table;
     }
 
-    public function __toString(): string
-    {
-        return (string)$this->table . "." . $this->name;
-    }
-
     public function getTable(): Table
     {
         return $this->table;
+    }
+
+    public function __toString(): string
+    {
+        return (string)$this->table . "." . $this->name;
     }
 
     public function isPartOfPrimaryKey() : bool
@@ -234,5 +235,15 @@ class Column implements Entity
         }
 
         return $capacity;
+    }
+
+    public function setCardinality(int $cardinality): void
+    {
+        $this->cardinality = $cardinality;
+    }
+
+    public function getCardinality(): int
+    {
+        return $this->cardinality;
     }
 }

--- a/src/Engine/Entity/Index.php
+++ b/src/Engine/Entity/Index.php
@@ -35,6 +35,11 @@ class Index implements Entity
         $this->table = $table;
     }
 
+    public function getTable(): Table
+    {
+        return $this->table;
+    }
+
     /**
      * @return bool
      */
@@ -90,6 +95,11 @@ class Index implements Entity
     public function setColumns(Column ...$columns): void
     {
         $this->columns = $columns;
+    }
+
+    public function getColumns(): array
+    {
+        return $this->columns;
     }
 
     public function __toString(): string

--- a/src/Engine/Entity/Index.php
+++ b/src/Engine/Entity/Index.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Cadfael\Engine\Entity;
 
 use Cadfael\Engine\Entity;
+use Cadfael\Engine\Entity\Index\Statistics;
 
 class Index implements Entity
 {
@@ -16,6 +17,8 @@ class Index implements Entity
     protected array $columns = [];
     protected bool $is_unique;
     protected int $size_in_bytes;
+
+    protected Statistics $statistics;
 
     public function __construct(string $name)
     {
@@ -56,6 +59,22 @@ class Index implements Entity
     public function isVirtual(): bool
     {
         return false;
+    }
+
+    /**
+     * @param \Cadfael\Engine\Entity\Index\Statistics $statistics
+     */
+    public function setStatistics(\Cadfael\Engine\Entity\Index\Statistics $statistics): void
+    {
+        $this->statistics = $statistics;
+    }
+
+    /**
+     * @return \Cadfael\Engine\Entity\Index\Statistics
+     */
+    public function getStatistics(): \Cadfael\Engine\Entity\Index\Statistics
+    {
+        return $this->statistics;
     }
 
     public function setSizeInBytes(int $bytes): void

--- a/src/Engine/Entity/Index/Statistics.php
+++ b/src/Engine/Entity/Index/Statistics.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cadfael\Engine\Entity\Index;
+
+/**
+ * Class AccessInformation
+ * @package Cadfael\Engine\Entity\Index
+ * @codeCoverageIgnore
+ */
+class Statistics
+{
+    public int $rows_selected;
+    public string $select_latency;
+    public int $rows_inserted;
+    public string $insert_latency;
+    public int $rows_updated;
+    public string $update_latency;
+    public int $rows_deleted;
+    public string $delete_latency;
+
+    protected function __construct()
+    {
+    }
+
+    /**
+     * @param array<string> $payload This is a raw record from sys.schema_index_statistics
+     * @return Statistics
+     */
+    public static function createFromSys(array $payload)
+    {
+        $statistics = new Statistics();
+        $statistics->rows_selected = (int)$payload["rows_selected"];
+        $statistics->select_latency = $payload["select_latency"];
+        $statistics->rows_inserted = (int)$payload["rows_inserted"];
+        $statistics->insert_latency = $payload["insert_latency"];
+        $statistics->rows_updated = (int)$payload["rows_updated"];
+        $statistics->update_latency = $payload["update_latency"];
+        $statistics->rows_deleted = (int)$payload["rows_deleted"];
+        $statistics->delete_latency = $payload["delete_latency"];
+
+        return $statistics;
+    }
+}

--- a/tests/Engine/Check/Index/LowCardinalityTest.php
+++ b/tests/Engine/Check/Index/LowCardinalityTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Cadfael\Tests\Engine\Check\Index;
+
+use Cadfael\Engine\Check\Index\LowCardinality;
+use Cadfael\Engine\Entity\Column;
+use Cadfael\Engine\Entity\Index;
+use Cadfael\Engine\Entity\Table;
+use Cadfael\Engine\Report;
+use Cadfael\Tests\Engine\Check\BaseTest;
+use Cadfael\Tests\Engine\Check\ColumnBuilder;
+use PHPUnit\Framework\TestCase;
+
+class LowCardinalityTest extends BaseTest
+{
+    protected Column $highCardinalityColumn;
+    protected Column $lowCardinalityColumn;
+
+    protected Index $highCardinalityIndex;
+    protected Index $lowCardinalityIndex;
+    protected Index $uniqueIndex;
+
+    protected Table $largeTable;
+    protected Table $mediumTable;
+    protected Table $smallTable;
+
+    public function setUp(): void
+    {
+        $this->largeTable = $this->createTable([ 'TABLE_ROWS' => 500_000 ]);
+        $this->mediumTable = $this->createTable([ 'TABLE_ROWS' => 10_000 ]);
+        $this->smallTable = $this->createTable([ 'TABLE_ROWS' => 50 ]);
+
+        $builder = new ColumnBuilder();
+        $this->highCardinalityColumn = $builder->name("high_cardinality_value")->generate();
+        $this->highCardinalityColumn->setCardinality(100_000);
+        $this->lowCardinalityColumn = $builder->name("low_cardinality_value")->generate();
+        $this->lowCardinalityColumn->setCardinality(10);
+
+        $this->highCardinalityIndex = new Index('high_cardinality_index');
+        $this->highCardinalityIndex->setColumns($this->highCardinalityColumn);
+        $this->highCardinalityIndex->setUnique(false);
+
+        $this->lowCardinalityIndex = new Index('low_cardinality_index');
+        $this->lowCardinalityIndex->setColumns($this->lowCardinalityColumn);
+        $this->lowCardinalityIndex->setUnique(false);
+
+        $this->uniqueIndex = new Index('unique_index');
+        $this->uniqueIndex->setColumns($this->highCardinalityColumn);
+        $this->uniqueIndex->setUnique(true);
+    }
+
+    public function testSupports()
+    {
+        $check = new LowCardinality();
+        $this->assertTrue($check->supports($this->highCardinalityIndex), "Ensure that the supports for a column returns true.");
+        $this->assertTrue($check->supports($this->lowCardinalityIndex), "Ensure that the supports for a column returns true.");
+        $this->assertTrue($check->supports($this->uniqueIndex), "Ensure that the supports for a column returns true.");
+    }
+
+    public function testRun()
+    {
+        $check = new LowCardinality();
+        $this->highCardinalityIndex->setTable($this->largeTable);
+        $this->assertEquals(
+            Report::STATUS_OK,
+            $check->run($this->highCardinalityIndex)->getStatus(),
+            "Ensure that an OK report is returned for $this->highCardinalityIndex with a large table."
+        );
+        $this->highCardinalityColumn->setTable($this->mediumTable);
+        $this->assertEquals(
+            Report::STATUS_OK,
+            $check->run($this->highCardinalityIndex)->getStatus(),
+            "Ensure that an OK report is returned for $this->highCardinalityIndex with a medium table."
+        );
+        $this->highCardinalityColumn->setTable($this->smallTable);
+        $this->assertEquals(
+            Report::STATUS_OK,
+            $check->run($this->highCardinalityIndex)->getStatus(),
+            "Ensure that an OK report is returned for $this->highCardinalityIndex with a small table."
+        );
+
+        $this->lowCardinalityIndex->setTable($this->largeTable);
+        $this->assertEquals(
+            Report::STATUS_WARNING,
+            $check->run($this->lowCardinalityIndex)->getStatus(),
+            "Ensure that an OK report is returned for $this->lowCardinalityIndex with a large table."
+        );
+        $this->lowCardinalityIndex->setTable($this->mediumTable);
+        $this->assertEquals(
+            Report::STATUS_CONCERN,
+            $check->run($this->lowCardinalityIndex)->getStatus(),
+            "Ensure that an OK report is returned for $this->lowCardinalityIndex with a medium table."
+        );
+        $this->lowCardinalityIndex->setTable($this->smallTable);
+        $this->assertEquals(
+            Report::STATUS_OK,
+            $check->run($this->lowCardinalityIndex)->getStatus(),
+            "Ensure that an OK report is returned for $this->lowCardinalityIndex with a small table."
+        );
+
+        $this->uniqueIndex->setTable($this->largeTable);
+        $this->assertEquals(
+            Report::STATUS_OK,
+            $check->run($this->uniqueIndex)->getStatus(),
+            "Ensure that an OK report is returned for $this->uniqueIndex with any table."
+        );
+    }
+}


### PR DESCRIPTION
Indexes with initial columns that have a low cardinality are potential bad indexes (either slow to query on or ignored in favour of other indexes which means wasted space/costs).