### PR TITLE
events_statements_summary_by_digest version fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,13 +119,13 @@ What is the database password?
 Try testing Cadfael on a few open data sources
 
 ```
-+-----------------------------+------+-----------+----------+-------------------------+
-| Host                        | Port | Username  | Password | Schema                  |
-+-----------------------------+------+-----------+----------+-------------------------+
-| ensembldb.ensembl.org       | 5306 | anonymous |          | ensembl_stable_ids_99   |
-| mysql-rfam-public.ebi.ac.uk | 4497 | rfamro    |          | Rfam                    |
-| mysql-db.1000genomes.org    | 4272 | anonymous |          | homo_sapiens_core_73_37 |
-+-----------------------------+------+-----------+----------+-------------------------+
++-----------------------------+------+-----------+----------+--------------------------+
+| Host                        | Port | Username  | Password | Schema                   |
++-----------------------------+------+-----------+----------+--------------------------+
+| ensembldb.ensembl.org       | 5306 | anonymous |          | homo_sapiens_core_103_38 |
+| mysql-rfam-public.ebi.ac.uk | 4497 | rfamro    |          | Rfam                     |
+| mysql-db.1000genomes.org    | 4272 | anonymous |          | homo_sapiens_core_73_37  |
++-----------------------------+------+-----------+----------+--------------------------+
 ```
 
 ## Contributions

--- a/src/Cli/Command/RunCommand.php
+++ b/src/Cli/Command/RunCommand.php
@@ -128,7 +128,7 @@ class RunCommand extends AbstractDatabaseCommand
             $output->writeln('Enabling performance_schema checks.');
             // Either the performance schema isn't enabled
             if (!$database->hasPerformanceSchema()) {
-                $output->writeln('<comment>This server does not performance_schema enabled.</comment>');
+                $output->writeln('<comment>This server does not have the performance_schema enabled.</comment>');
                 $output->writeln('<comment>Disabling the flag and continuing.</comment>');
                 $load_performance_schema = false;
             // Or we don't have access to it

--- a/src/Engine/Entity/Database.php
+++ b/src/Engine/Entity/Database.php
@@ -40,7 +40,8 @@ class Database implements Entity
 
     public function getName(): string
     {
-        return $this->getConnection()->getHost();
+        return $this->getConnection()->getHost() .
+            ($this->getConnection()->getPort() ? ':' . $this->getConnection()->getPort() : '');
     }
 
     public function __toString(): string

--- a/src/Engine/Entity/Database.php
+++ b/src/Engine/Entity/Database.php
@@ -40,7 +40,7 @@ class Database implements Entity
 
     public function getName(): string
     {
-        return $this->getConnection()->getHost() . ':' . $this->getConnection()->getPort();
+        return $this->getConnection()->getHost();
     }
 
     public function __toString(): string

--- a/src/Engine/Entity/Query/EventsStatementsSummary.php
+++ b/src/Engine/Entity/Query/EventsStatementsSummary.php
@@ -88,12 +88,14 @@ class EventsStatementsSummary
         $summary->sum_no_good_index_used = (int)$schema['SUM_NO_GOOD_INDEX_USED'];
         $summary->first_seen = self::convertToDateTime($schema['FIRST_SEEN']);
         $summary->last_seen = self::convertToDateTime($schema['LAST_SEEN']);
-        $summary->quantile_95 = (int)$schema['QUANTILE_95'];
-        $summary->quantile_99 = (int)$schema['QUANTILE_99'];
-        $summary->quantile_999 = (int)$schema['QUANTILE_999'];
-        $summary->query_sample_text = $schema['QUERY_SAMPLE_TEXT'];
-        $summary->query_sample_seen = self::convertToDateTime($schema['QUERY_SAMPLE_SEEN']);
-        $summary->query_sample_timer_wait = (int)$schema['QUERY_SAMPLE_TIMER_WAIT'];
+        if (isset($schema['QUERY_SAMPLE_TEXT'])) {
+            $summary->quantile_95 = (int)$schema['QUANTILE_95'];
+            $summary->quantile_99 = (int)$schema['QUANTILE_99'];
+            $summary->quantile_999 = (int)$schema['QUANTILE_999'];
+            $summary->query_sample_text = $schema['QUERY_SAMPLE_TEXT'];
+            $summary->query_sample_seen = self::convertToDateTime($schema['QUERY_SAMPLE_SEEN']);
+            $summary->query_sample_timer_wait = (int)$schema['QUERY_SAMPLE_TIMER_WAIT'];
+        }
 
         return $summary;
     }

--- a/src/Engine/Entity/Schema.php
+++ b/src/Engine/Entity/Schema.php
@@ -17,12 +17,12 @@ class Schema implements Entity
     /**
      * @var array<Table>
      */
-    protected array $tables;
+    protected array $tables = [];
 
     /**
      * @var array<Query>
      */
-    protected array $queries;
+    protected array $queries = [];
 
     protected Database $database;
 

--- a/src/Engine/Factory.php
+++ b/src/Engine/Factory.php
@@ -76,7 +76,8 @@ class Factory
         }, $this->connection->fetchAll($query));
     }
 
-    private function getEventStatementsSummary(Schema $schema) {
+    private function getEventStatementsSummary(Schema $schema): void
+    {
         try {
             // Collect all query digests that have been run so far.
             $statement = $this->getConnection()->prepare("

--- a/src/Engine/Factory.php
+++ b/src/Engine/Factory.php
@@ -278,7 +278,7 @@ class Factory
             $statement->bindValue("schema", $schema_name);
             $statement->execute();
 
-            $rows = $statement->fetchAll();
+            $rows = $statement->fetchAllAssociative();
             $tables = [];
             foreach ($rows as $row) {
                 $table = Table::createFromInformationSchema($row);
@@ -292,7 +292,7 @@ class Factory
             $statement->bindValue("schema", $schema_name);
             $statement->execute();
 
-            $rows = $statement->fetchAll();
+            $rows = $statement->fetchAllAssociative();
             $columns = [];
             foreach ($rows as $row) {
                 $column = Column::createFromInformationSchema($row);
@@ -306,7 +306,7 @@ class Factory
             $statement->bindValue("schema", $schema_name);
             $statement->execute();
 
-            $rows = $statement->fetchAll();
+            $rows = $statement->fetchAllAssociative();
             $indexes = [];
             $indexUnique = [];
             foreach ($rows as $row) {
@@ -331,7 +331,7 @@ class Factory
                     $statement->bindValue("schema", $schema_name);
                     $statement->execute();
 
-                    $rows = $statement->fetchAll();
+                    $rows = $statement->fetchAllAssociative();
                     foreach ($rows as $row) {
                         $autoIncrementColumns[$row['table_name']] = SchemaAutoIncrementColumn::createFromSys($row);
                     }
@@ -346,7 +346,7 @@ class Factory
                     $statement->bindValue("schema", $schema_name);
                     $statement->execute();
 
-                    $rows = $statement->fetchAll();
+                    $rows = $statement->fetchAllAssociative();
                     foreach ($rows as $row) {
                         $schemaRedundantIndexes[$row['table_name']][] = SchemaRedundantIndex::createFromSys(
                             $tables[$row['table_name']],
@@ -364,7 +364,7 @@ class Factory
                     $statement->bindValue("schema", $schema_name);
                     $statement->execute();
 
-                    $rows = $statement->fetchAll();
+                    $rows = $statement->fetchAllAssociative();
                     foreach ($rows as $row) {
                         $index_statistics[$row['table_name']][$row['index_name']] = Statistics::createFromSys($row);
                     }
@@ -389,7 +389,7 @@ class Factory
                 ");
                 $statement->bindValue("schema", $schema->getName());
                 $statement->execute();
-                foreach ($statement->fetchAll() as $row) {
+                foreach ($statement->fetchAllAssociative() as $row) {
                     $size = $row['stat_value'] * $database->getVariables()['innodb_page_size'];
                     $indexSize[$row['table_name']][$row['index_name']] = $size;
                 }
@@ -424,7 +424,7 @@ class Factory
                 ");
                 $statement->bindValue("schema", $schema->getName());
                 $statement->execute();
-                foreach ($statement->fetchAll() as $row) {
+                foreach ($statement->fetchAllAssociative() as $row) {
                     $index = $table_indexes_objects[$row['object_name']][$row['index_name']];
                     $schema_unused_indexes[$row['object_name']][] = new SchemaUnusedIndex($index);
                 }
@@ -481,7 +481,7 @@ class Factory
                 $statement->bindValue("schema", $schema_name);
                 $statement->execute();
 
-                $access_requests = $statement->fetchAll();
+                $access_requests = $statement->fetchAllAssociative();
                 foreach ($access_requests as $access_request) {
                     $table_access_information[$access_request['OBJECT_NAME']] = new AccessInformation(
                         (int)$access_request['COUNT_READ'],


### PR DESCRIPTION
Older versions of MySQL have a shorter list of columns for `performance_schema.events_statements_summary_by_digest`.

This breaks when we attempt to load this. This change attempts to fix this.