### PR TITLE
Tablespace

### DIFF
--- a/src/Engine/Entity/Database.php
+++ b/src/Engine/Entity/Database.php
@@ -29,6 +29,11 @@ class Database implements Entity
      */
     protected array $accounts;
 
+    /**
+     * @var array<Tablespace>
+     */
+    protected array $tablespaces;
+
     private Connection $connection;
 
     public function __construct(?Connection $connection)
@@ -119,6 +124,39 @@ class Database implements Entity
     public function addAccount(Account $account): void
     {
         $this->accounts[] = $account;
+    }
+
+    /**
+     * @codeCoverageIgnore
+     * Skip coverage as this is a basic accessor. Remove if the accessor behaviour becomes more complicated.
+     *
+     * @return string[]
+     */
+    public function getTablespaces(): array
+    {
+        return $this->tablespaces;
+    }
+
+    public function getTablespace(int $id): ?Tablespace
+    {
+        foreach ($this->tablespaces as $tablespace) {
+            if ($tablespace->getId() === $id) {
+                return $tablespace;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @codeCoverageIgnore
+     * Skip coverage as this is a basic accessor. Remove if the accessor behaviour becomes more complicated.
+     *
+     * @param Tablespace ...$tablespaces
+     */
+    public function setTablespaces(Tablespace...$tablespaces): void
+    {
+        $this->tablespaces = $tablespaces;
     }
 
     /**

--- a/src/Engine/Entity/Table.php
+++ b/src/Engine/Entity/Table.php
@@ -7,6 +7,7 @@ namespace Cadfael\Engine\Entity;
 use Cadfael\Engine\Entity;
 use Cadfael\Engine\Entity\Table\AccessInformation;
 use Cadfael\Engine\Entity\Table\InformationSchema;
+use Cadfael\Engine\Entity\Table\InnoDbTable;
 use Cadfael\Engine\Entity\Table\SchemaAutoIncrementColumn;
 use Cadfael\Engine\Entity\Table\SchemaRedundantIndex;
 use Cadfael\Engine\Entity\Table\SchemaUnusedIndex;
@@ -33,6 +34,7 @@ class Table implements Entity
     public ?InformationSchema $information_schema = null;
     public ?SchemaAutoIncrementColumn $schema_auto_increment_column = null;
     public ?AccessInformation $access_information = null;
+    public ?InnoDbTable $innodb_table = null;
     /**
      * @var array<SchemaRedundantIndex>
      */
@@ -184,6 +186,28 @@ class Table implements Entity
     public function setAccessInformation(AccessInformation $access_information): void
     {
         $this->access_information = $access_information;
+    }
+
+    /**
+     * @codeCoverageIgnore
+     * Skip coverage as this is a basic accessor. Remove if the accessor behaviour becomes more complicated.
+     *
+     * @param InnoDbTable $innodb_table
+     */
+    public function setInnoDbTable(InnoDbTable $innodb_table): void
+    {
+        $this->innodb_table = $innodb_table;
+    }
+
+    public function getTableSpace(): ?Tablespace
+    {
+        if (!$this->innodb_table) {
+            return null;
+        }
+
+        // Our database holds all the tablespaces
+        $database = $this->getSchema()->getDatabase();
+        return $database->getTablespace($this->innodb_table->space);
     }
 
     public function isVirtual(): bool

--- a/src/Engine/Entity/Table/InnoDbTable.php
+++ b/src/Engine/Entity/Table/InnoDbTable.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Cadfael\Engine\Entity\Table;
+
+class InnoDbTable
+{
+    public int $table_id;
+    public int $space;
+    public string $name;
+    public int $flag;
+    public int $n_cols;
+    /**
+     * @type Enum
+     * @Enum Any, Compact or Redundant, Undo, Dynamic
+     */
+    public string $row_format;
+    public int $zip_page_size;
+    /**
+     * @type Enum
+     * @Enum General, System, Undo, Single
+     */
+    public string $space_type;
+    public int $instant_cols;
+
+    private function __construct()
+    {
+    }
+
+    /**
+     * @param array<string> $schema This is a raw record from information_schema.innodb_tables or
+     * information_schema.innodb_sys_tables (depending on version of MySQL)
+     * @return InnoDbTable
+     */
+    public static function createFromInformationSchema(array $schema): InnoDbTable
+    {
+        $informationSchema = new InnoDbTable();
+        $informationSchema->table_id = (int)$schema['TABLE_ID'];
+        $informationSchema->space = (int)$schema['SPACE'];
+        $informationSchema->name = (string)$schema['NAME'];
+        $informationSchema->flag = (int)$schema['FLAG'];
+        $informationSchema->n_cols = (int)$schema['N_COLS'];
+        $informationSchema->row_format = (string)$schema['ROW_FORMAT'];
+        $informationSchema->zip_page_size = (int)$schema['ZIP_PAGE_SIZE'];
+        $informationSchema->space_type = (string)$schema['SPACE_TYPE'];
+        $informationSchema->instant_cols = (int)$schema['INSTANT_COLS'];
+        return $informationSchema;
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString(): string
+    {
+        return $this->name;
+    }
+}

--- a/src/Engine/Entity/Tablespace.php
+++ b/src/Engine/Entity/Tablespace.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Cadfael\Engine\Entity;
+
+use Cadfael\Engine\Entity;
+
+class Tablespace implements Entity
+{
+    /**
+     * @var int
+     */
+    public int $id;
+
+    /**
+     * @var string
+     */
+    public string $name;
+    public int $flag;
+    public string $row_format;
+    public int $page_size;
+    public int $zip_page_size;
+    public string $space_type;
+    public int $fs_block_size;
+    public int $file_size;
+    public int $allocated_size;
+    public int $autoextend_size;
+    public string $server_version;
+    public int $space_version;
+    public bool $encryption;
+    public string $state;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @param array<string> $schema This is a raw record from information_schema.TABLE
+     * @return Tablespace
+     */
+    public static function createFromInformationSchema(array $schema): Tablespace
+    {
+        $table = new Tablespace((string)$schema['NAME']);
+        $table->id = (int)$schema['SPACE'];
+        $table->flag = (int)$schema['FLAG'];
+        $table->row_format = (string)$schema['ROW_FORMAT'];
+        $table->page_size = (int)$schema['PAGE_SIZE'];
+        $table->zip_page_size = (int)$schema['ZIP_PAGE_SIZE'];
+        $table->space_type = (string)$schema['SPACE_TYPE'];
+        $table->fs_block_size = (int)$schema['FS_BLOCK_SIZE'];
+        $table->file_size = (int)$schema['FILE_SIZE'];
+        $table->allocated_size = (int)$schema['ALLOCATED_SIZE'];
+        $table->autoextend_size = (int)$schema['AUTOEXTEND_SIZE'];
+        $table->server_version = (string)$schema['SERVER_VERSION'];
+        $table->space_version = (int)$schema['SPACE_VERSION'];
+        $table->encryption = (bool)$schema['ENCRYPTION'];
+        $table->state = (string)$schema['STATE'];
+
+        return $table;
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function isVirtual(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString(): string
+    {
+        return $this->getName();
+    }
+}

--- a/tests/Engine/Check/Table/EmptyTableTest.php
+++ b/tests/Engine/Check/Table/EmptyTableTest.php
@@ -31,9 +31,23 @@ class EmptyTableTest extends BaseTest
 
     public function providerTableDataForRun() {
         $builder = new ColumnBuilder();
-        $column = $builder->int(10)->unsigned()->primary()->auto_increment()->generate();
+        $column = $builder->int(10)
+            ->unsigned()
+            ->primary()
+            ->auto_increment()
+            ->generate();
         $table = $this->createEmptyTable();
         $table->setColumns($column);
+
+        $column = $builder->int(10)
+            ->unsigned()
+            ->primary()
+            ->auto_increment()
+            ->generate();
+        $table_with_inserts = $this->createEmptyTable();
+        $table_with_inserts->setColumns($column);
+        $auto_increment = $table_with_inserts->getSchemaAutoIncrementColumn();
+        $auto_increment->auto_increment = 10;
 
         return [
             [
@@ -41,8 +55,12 @@ class EmptyTableTest extends BaseTest
                 Report::STATUS_WARNING
             ],
             [
+                $table_with_inserts,
+                Report::STATUS_CONCERN
+            ],
+            [
                 $this->createEmptyTable([ "DATA_FREE" => 110 ]),
-                Report::STATUS_INFO
+                Report::STATUS_CONCERN
             ],
             [
                 $this->createTable(),


### PR DESCRIPTION
Added innodb_table and tablespace meta and improved the empty table check.
    
New meta data from information_schema collected and linked to tables and database to support tablespace specific checks (for issue #24)

Built-in tablespaces mean that even new empty tables may have `DATA_FREE` which means we can't guess if the table has been used already (for issue #19)
