### PR TITLE
Ignore .phpunit.result.cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.phar
 build/
 resources/
 cadfael.phar
+.phpunit.result.cache


### PR DESCRIPTION
When running `make` the file _.phpunit.result.cache_ gets created every time.

Since it should not be tracked in git, it's better to put in `.gitignore`