### PR TITLE
Shifted index meta data into sub-classes

### DIFF
--- a/src/Engine/Entity/Index.php
+++ b/src/Engine/Entity/Index.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Cadfael\Engine\Entity;
 
 use Cadfael\Engine\Entity;
+use Cadfael\Engine\Entity\Index\SchemaIndexStatistics;
 use Cadfael\Engine\Entity\Index\Statistics;
 
 class Index implements Entity
@@ -12,13 +13,13 @@ class Index implements Entity
     protected string $name;
     protected Table $table;
     /**
-     * @var array<Column>
+     * @var array<Statistics>
      */
-    protected array $columns = [];
+    protected array $statistics = [];
     protected bool $is_unique;
     protected int $size_in_bytes;
 
-    protected Statistics $statistics;
+    protected SchemaIndexStatistics $schema_index_statistics;
 
     public function __construct(string $name)
     {
@@ -67,19 +68,32 @@ class Index implements Entity
     }
 
     /**
-     * @param \Cadfael\Engine\Entity\Index\Statistics $statistics
+     * @param SchemaIndexStatistics $schema_index_statistics
      */
-    public function setStatistics(\Cadfael\Engine\Entity\Index\Statistics $statistics): void
+    public function setSchemaIndexStatistics(SchemaIndexStatistics $schema_index_statistics): void
     {
-        $this->statistics = $statistics;
+        $this->schema_index_statistics = $schema_index_statistics;
     }
 
     /**
-     * @return \Cadfael\Engine\Entity\Index\Statistics
+     * @return SchemaIndexStatistics
      */
-    public function getStatistics(): \Cadfael\Engine\Entity\Index\Statistics
+    public function getSchemaIndexStatistics(): SchemaIndexStatistics
     {
-        return $this->statistics;
+        return $this->schema_index_statistics;
+    }
+
+    /**
+     * @return array<Column>
+     */
+    public function getColumns(): array
+    {
+        return array_map(
+            function (Statistics $statistics) : Column {
+                return $statistics->column;
+            },
+            $this->getStatistics()
+        );
     }
 
     public function setSizeInBytes(int $bytes): void
@@ -92,14 +106,14 @@ class Index implements Entity
         return $this->size_in_bytes;
     }
 
-    public function setColumns(Column ...$columns): void
+    public function setStatistics(Statistics ...$statistics): void
     {
-        $this->columns = $columns;
+        $this->statistics = $statistics;
     }
 
-    public function getColumns(): array
+    public function getStatistics(): array
     {
-        return $this->columns;
+        return $this->statistics;
     }
 
     public function __toString(): string

--- a/src/Engine/Entity/Index/SchemaIndexStatistics.php
+++ b/src/Engine/Entity/Index/SchemaIndexStatistics.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cadfael\Engine\Entity\Index;
+
+/**
+ * Class AccessInformation
+ * @package Cadfael\Engine\Entity\Index
+ * @codeCoverageIgnore
+ */
+class SchemaIndexStatistics
+{
+    public int $rows_selected;
+    public string $select_latency;
+    public int $rows_inserted;
+    public string $insert_latency;
+    public int $rows_updated;
+    public string $update_latency;
+    public int $rows_deleted;
+    public string $delete_latency;
+
+    protected function __construct()
+    {
+    }
+
+    /**
+     * @param array<string> $payload This is a raw record from sys.schema_index_statistics
+     * @return SchemaIndexStatistics
+     */
+    public static function createFromSys(array $payload)
+    {
+        $statistics = new SchemaIndexStatistics();
+        $statistics->rows_selected = (int)$payload["rows_selected"];
+        $statistics->select_latency = $payload["select_latency"];
+        $statistics->rows_inserted = (int)$payload["rows_inserted"];
+        $statistics->insert_latency = $payload["insert_latency"];
+        $statistics->rows_updated = (int)$payload["rows_updated"];
+        $statistics->update_latency = $payload["update_latency"];
+        $statistics->rows_deleted = (int)$payload["rows_deleted"];
+        $statistics->delete_latency = $payload["delete_latency"];
+
+        return $statistics;
+    }
+}

--- a/src/Engine/Entity/Index/Statistics.php
+++ b/src/Engine/Entity/Index/Statistics.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Cadfael\Engine\Entity\Index;
 
+use Cadfael\Engine\Entity\Column;
+
 /**
  * Class AccessInformation
  * @package Cadfael\Engine\Entity\Index
@@ -11,34 +13,43 @@ namespace Cadfael\Engine\Entity\Index;
  */
 class Statistics
 {
-    public int $rows_selected;
-    public string $select_latency;
-    public int $rows_inserted;
-    public string $insert_latency;
-    public int $rows_updated;
-    public string $update_latency;
-    public int $rows_deleted;
-    public string $delete_latency;
+    public Column $column;
+    public int $seq_in_index;
+    public ?string $collation;
+    public ?string $cardinality;
+    public ?int $sub_part;
+    public ?int $packed;
+    public bool $nullable;
+    public string $index_type;
+    public string $comment;
+    public string $index_comment;
+    public ?bool $is_visible;
+    public ?string $expression;
 
     protected function __construct()
     {
     }
 
     /**
-     * @param array<string> $payload This is a raw record from sys.schema_index_statistics
+     * @param Column $column
+     * @param array<string> $payload This is a raw record from information_schema.statistics
      * @return Statistics
      */
-    public static function createFromSys(array $payload)
+    public static function createFromInformationSchema(Column $column, array $payload): Statistics
     {
         $statistics = new Statistics();
-        $statistics->rows_selected = (int)$payload["rows_selected"];
-        $statistics->select_latency = $payload["select_latency"];
-        $statistics->rows_inserted = (int)$payload["rows_inserted"];
-        $statistics->insert_latency = $payload["insert_latency"];
-        $statistics->rows_updated = (int)$payload["rows_updated"];
-        $statistics->update_latency = $payload["update_latency"];
-        $statistics->rows_deleted = (int)$payload["rows_deleted"];
-        $statistics->delete_latency = $payload["delete_latency"];
+        $statistics->column = $column;
+        $statistics->seq_in_index = (int)$payload['SEQ_IN_INDEX'];
+        $statistics->collation = $payload['COLLATION'];
+        $statistics->cardinality = $payload['CARDINALITY'];
+        $statistics->sub_part = (int)$payload['SUB_PART'];
+        $statistics->packed = isset($payload['PACKED']) ? (int)$payload['PACKED'] : null;
+        $statistics->nullable = $payload['NULLABLE'] == 'YES';
+        $statistics->index_type = $payload['INDEX_TYPE'];
+        $statistics->comment = $payload['COMMENT'];
+        $statistics->index_comment = $payload['INDEX_COMMENT'];
+        $statistics->is_visible = isset($payload['IS_VISIBLE']) ? (bool)$payload['IS_VISIBLE'] : null;
+        $statistics->expression = $payload['EXPRESSION'] ?? null;
 
         return $statistics;
     }

--- a/src/Engine/Entity/Table/SchemaRedundantIndex.php
+++ b/src/Engine/Entity/Table/SchemaRedundantIndex.php
@@ -58,30 +58,16 @@ class SchemaRedundantIndex
     }
 
     /**
-     * @param Table $table
+     * @param array<Index> $indexes Hash of indexes (key is index name, value is Index object)
      * @param array<string> $schema This is a raw record from sys.schema_redundant_indexes
      * @return SchemaRedundantIndex
      */
-    public static function createFromSys(Table $table, array $schema): SchemaRedundantIndex
+    public static function createFromSys(array $indexes, array $schema): SchemaRedundantIndex
     {
-        $redundantIndex = new Index($schema['redundant_index_name']);
-        $redundantIndex->setTable($table);
-        $redundantIndex->setColumns(
-            ...self::getFilteredColumns(
-                $table,
-                explode(',', $schema['redundant_index_columns'])
-            )
-        );
+        $redundantIndex = $indexes[$schema['redundant_index_name']];
         $redundantIndex->setUnique(!(bool)$schema['redundant_index_non_unique']);
 
-        $dominantIndex = new Index($schema['dominant_index_name']);
-        $dominantIndex->setTable($table);
-        $dominantIndex->setColumns(
-            ...self::getFilteredColumns(
-                $table,
-                explode(',', $schema['dominant_index_columns'])
-            )
-        );
+        $dominantIndex = $indexes[$schema['dominant_index_name']];
         $dominantIndex->setUnique(!(bool)$schema['dominant_index_non_unique']);
 
         return new SchemaRedundantIndex(

--- a/tests/Engine/Check/IndexBuilder.php
+++ b/tests/Engine/Check/IndexBuilder.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cadfael\Tests\Engine\Check;
+
+use Cadfael\Engine\Entity\Column;
+use Cadfael\Engine\Entity\Index;
+use Cadfael\Engine\Entity\Index\Statistics;
+
+class IndexBuilder
+{
+    const BASE = [
+        "TABLE_CATALOG" => "def",
+        "TABLE_SCHEMA" => "MOCK_SCHEMA",
+        "TABLE_NAME" => "MOCK_TABLE",
+        "NON_UNIQUE" => "1",
+        "INDEX_SCHEMA" => "MOCK_SCHEMA",
+        "INDEX_NAME" => "MOCK_INDEX",
+        "SEQ_IN_INDEX" => "1",
+        "COLUMN_NAME" => "MOCK_COLUMN",
+        "COLLATION" => "A",
+        "CARDINALITY" => "0",
+        "SUB_PART" => NULL,
+        "PACKED" => NULL,
+        "NULLABLE" => "",
+        "INDEX_TYPE" => "BTREE",
+        "COMMENT" => "",
+        "INDEX_COMMENT" => "",
+        "IS_VISIBLE" => "YES",
+        "EXPRESSION" => NULL,
+    ];
+
+    private $override = [];
+    private ?Column $column = null;
+
+    public function name($name): IndexBuilder
+    {
+        $this->override['INDEX_NAME'] = $name;
+        return $this;
+    }
+
+    public function cardinality($cardinality): IndexBuilder
+    {
+        $this->override['CARDINALITY'] = $cardinality;
+        return $this;
+    }
+
+    public function isUnique(bool $unique): IndexBuilder
+    {
+        $this->override['NON_UNIQUE'] = $unique ? "0" : "1";
+        return $this;
+    }
+
+    public function setColumn(Column $column): IndexBuilder
+    {
+        $this->column = $column;
+        return $this;
+    }
+
+    public function generate(): Index
+    {
+        $statistics = array_merge(
+            self::BASE,
+            $this->override
+        );
+
+        $column = $this->column;
+        if (!$column) {
+            $builder = new ColumnBuilder();
+            $column = $builder->name($statistics['INDEX_NAME'])
+                ->generate();
+        }
+
+        $index = new Index($statistics['INDEX_NAME']);
+        $index->setUnique(!(bool)$statistics['NON_UNIQUE']);
+        $index->setStatistics(Statistics::createFromInformationSchema($column, $statistics));
+
+        $this->override = [];
+        $this->column = null;
+
+        return $index;
+    }
+}

--- a/tests/Engine/Check/Table/RedundantIndexesTest.php
+++ b/tests/Engine/Check/Table/RedundantIndexesTest.php
@@ -7,6 +7,7 @@ use Cadfael\Engine\Check\Table\RedundantIndexes;
 use Cadfael\Engine\Entity\Table\SchemaRedundantIndex;
 use Cadfael\Engine\Report;
 use Cadfael\Tests\Engine\Check\BaseTest;
+use Cadfael\Tests\Engine\Check\IndexBuilder;
 
 class RedundantIndexesTest extends BaseTest
 {
@@ -24,10 +25,16 @@ class RedundantIndexesTest extends BaseTest
     }
 
     public function providerTableDataForRun() {
+        $builder = new IndexBuilder();
+        $indexes = [
+            "id_some" => $builder->name("id_some")->generate(),
+            "PRIMARY" => $builder->name("PRIMARY")->generate()
+        ];
+
         $tableWithRedundantIndex = $this->createTable();
         $tableWithRedundantIndex->setSchemaRedundantIndexes(
             SchemaRedundantIndex::createFromSys(
-                $tableWithRedundantIndex,
+                $indexes,
                 [
                     "table_schema"                  => "tests",
                     "table_name"                    => "table_with_unused_index",

--- a/tests/Engine/Check/Table/SaneInnoDbPrimaryKeyTest.php
+++ b/tests/Engine/Check/Table/SaneInnoDbPrimaryKeyTest.php
@@ -8,6 +8,7 @@ use Cadfael\Engine\Report;
 
 use Cadfael\Tests\Engine\Check\BaseTest;
 use Cadfael\Tests\Engine\Check\ColumnBuilder;
+use Cadfael\Tests\Engine\Check\IndexBuilder;
 
 
 class SaneInnoDbPrimaryKeyTest extends BaseTest
@@ -54,6 +55,8 @@ class SaneInnoDbPrimaryKeyTest extends BaseTest
     {
         $check = new SaneInnoDbPrimaryKey();
 
+        $builder = new IndexBuilder();
+
         $this->assertNull($check->run($this->createTable()), "Ensure table without a PRIMARY KEY is ignored.");
 
         $tableWithNoOtherIndex = $this->createTable();
@@ -63,40 +66,35 @@ class SaneInnoDbPrimaryKeyTest extends BaseTest
         $smallIndexColumn = clone $this->intColumn;
         $tableWithSmallIndex = $this->createTable();
         $tableWithSmallIndex->setColumns(clone $this->simplePrimaryKeyColumn, $smallIndexColumn);
-        $index = new Index('simple');
-        $index->setColumns($smallIndexColumn);
+        $index = $builder->name('simple')->setColumn($smallIndexColumn)->generate();
         $tableWithSmallIndex->setIndexes($index);
         $this->assertEquals(Report::STATUS_OK, $check->run($tableWithSmallIndex)->getStatus(), "Ensure table with a small PRIMARY KEY and a small indexes is fine.");
 
         $largeIndexColumn = clone $this->stringColumn;
         $tableWithLargeIndex = $this->createTable();
         $tableWithLargeIndex->setColumns(clone $this->simplePrimaryKeyColumn, $largeIndexColumn);
-        $index = new Index('large');
-        $index->setColumns($largeIndexColumn);
+        $index = $builder->name('large')->setColumn($largeIndexColumn)->generate();
         $tableWithLargeIndex->setIndexes($index);
         $this->assertEquals(Report::STATUS_OK, $check->run($tableWithLargeIndex)->getStatus(), "Ensure table with a small PRIMARY KEY and a large indexes is fine.");
 
         $smallIndexColumn = clone $this->intColumn;
         $tableWithMediumPrimaryAndSmallIndex = $this->createTable();
         $tableWithMediumPrimaryAndSmallIndex->setColumns(clone $this->mediumPrimaryKeyColumn, $smallIndexColumn);
-        $index = new Index('simple');
-        $index->setColumns($smallIndexColumn);
+        $index = $builder->name('simple')->setColumn($smallIndexColumn)->generate();
         $tableWithMediumPrimaryAndSmallIndex->setIndexes($index);
         $this->assertEquals(Report::STATUS_OK, $check->run($tableWithMediumPrimaryAndSmallIndex)->getStatus(), "Ensure table with a medium PRIMARY KEY and a small indexes is a warning.");
 
         $smallIndexColumn = clone $this->intColumn;
         $tableWithLargePrimaryAndSmallIndex = $this->createTable();
         $tableWithLargePrimaryAndSmallIndex->setColumns(clone $this->complexPrimaryKeyColumn, $smallIndexColumn);
-        $index = new Index('simple');
-        $index->setColumns($smallIndexColumn);
+        $index = $builder->name('simple')->setColumn($smallIndexColumn)->generate();
         $tableWithLargePrimaryAndSmallIndex->setIndexes($index);
         $this->assertEquals(Report::STATUS_WARNING, $check->run($tableWithLargePrimaryAndSmallIndex)->getStatus(), "Ensure table with a large PRIMARY KEY and a small indexes is a warning.");
 
         $largeIndexColumn = clone $this->stringColumn;
         $tableWithLargePrimaryAndLargeIndex = $this->createTable();
         $tableWithLargePrimaryAndLargeIndex->setColumns(clone $this->complexPrimaryKeyColumn, $largeIndexColumn);
-        $index = new Index('large');
-        $index->setColumns($largeIndexColumn);
+        $index = $builder->name('large')->setColumn($largeIndexColumn)->generate();
         $tableWithLargePrimaryAndLargeIndex->setIndexes($index);
         $this->assertEquals(Report::STATUS_WARNING, $check->run($tableWithLargePrimaryAndLargeIndex)->getStatus(), "Ensure table with a large PRIMARY KEY and a large indexes is a warning.");
     }


### PR DESCRIPTION
Shifted `information_schema.STATISTICS` and `sys.schema_index_statistics` into their own classes (and with full names to avoid confusion).

Index now contains an array of `information_schema.STATISTICS` records that reference which columns an index is made up of as well as additional meta data about the column itself (such as `SUB_PART`).

This is needed to support issue #10 (Index limit for text types).

Various refactoring of the build process and tests were required as well as various additional checks to avoid exceptions being thrown during the factory's meta data extraction.