### PR TITLE
Exit non supported versions Issue #20

### DIFF
--- a/src/Engine/Exception/NonSupportedVersion.php
+++ b/src/Engine/Exception/NonSupportedVersion.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cadfael\Engine\Exception;
+
+class NonSupportedVersion extends \Exception
+{
+}

--- a/src/Engine/Factory.php
+++ b/src/Engine/Factory.php
@@ -283,13 +283,13 @@ class Factory
      */
     protected function checkMySqlVersion(Database $database): void
     {
-        $message = '%s is not a supported version of MySQL.';
+        $message = '%s is not a supported version of MySQL. Please upgrade to %s or higher.';
         // Get the database version
         $version = $database->getVersion();
         // Check if the version is supported
         if (version_compare($version, self::MIN_SUPPORTED_VERSION, '<')) {
-            $this->logger->warning(sprintf($message, $version));
-            throw new NonSupportedVersion(sprintf($message, $version));
+            $this->logger->warning(sprintf($message, $version, self::MIN_SUPPORTED_VERSION));
+            throw new NonSupportedVersion(sprintf($message, $version, self::MIN_SUPPORTED_VERSION));
         }
     }
 

--- a/src/Engine/Factory.php
+++ b/src/Engine/Factory.php
@@ -23,6 +23,7 @@ use Cadfael\Engine\Entity\Tablespace;
 use Cadfael\Engine\Entity\Index\SchemaIndexStatistics;
 use Cadfael\Engine\Exception\MissingPermissions;
 use Cadfael\Engine\Exception\MissingInformationSchema;
+use Cadfael\Engine\Exception\NonSupportedVersion;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception\InvalidFieldNameException;
 use Psr\Log\LoggerAwareTrait;
@@ -49,6 +50,9 @@ class Factory
      * @var array<bool>
      */
     private $table_lookup = [];
+
+    // We don't want to support versions of MySQL before 5.6.
+    private const MIN_SUPPORTED_VERSION = '5.6.0';
 
     // TODO: Move permission related functionality to a subclass
 
@@ -274,6 +278,22 @@ class Factory
     }
 
     /**
+     * @param Database $database
+     * @throws NonSupportedVersion
+     */
+    protected function checkMySqlVersion(Database $database): void
+    {
+        $message = '%s is not a supported version of MySQL.';
+        // Get the database version
+        $version = $database->getVersion();
+        // Check if the version is supported
+        if (version_compare($version, self::MIN_SUPPORTED_VERSION, '<')) {
+            $this->logger->warning(sprintf($message, $version));
+            throw new NonSupportedVersion(sprintf($message, $version));
+        }
+    }
+
+    /**
      * @param Connection $connection
      * @return array<string>
      * @throws \Doctrine\DBAL\Exception
@@ -425,6 +445,8 @@ class Factory
         $database->setStatus($this->getStatus($connection));
         $database->setAccounts(...$this->getAccounts($connection));
         $database->setTablespaces(...$this->getTablespaces($connection));
+
+        $this->checkMySqlVersion($database);
 
         $schemas = [];
         foreach ($schema_names as $schema_name) {


### PR DESCRIPTION
Implements #20 

This PR includes:
- A `checkMySqlVersion` method on Factory class to check the `MIN_SUPPORTED_VERSION = '5.6.0'`
- The check is performed after Database initialization

```
cadfael run --host 127.0.0.1 --username root --port 3306 test
Cadfael CLI Tool

Host: 127.0.0.1:3306
User: root

What is the database password? 


In Factory.php line 290:
                                               
5.5.41 is not a supported version of MySQL.  
                                               

run [--host HOST] [-p|--port PORT] [-u|--username USERNAME] [--performance_schema] [--] <schema>...

```
