### PR TITLE
Blacklist vendors to reduce phar output size.

### DIFF
--- a/box.json
+++ b/box.json
@@ -1,5 +1,26 @@
 {
   "force-autodiscovery": true,
   "main": "bin/cadfael",
+  "blacklist": [
+    "vendor/amphp",
+    "vendor/dnoegel",
+    "vendor/felixfbecker",
+    "vendor/myclabs",
+    "vendor/netresearch",
+    "vendor/nikic",
+    "vendor/openlss",
+    "vendor/phar-io",
+    "vendor/phpdocumentor",
+    "vendor/phpspec",
+    "vendor/phpstan",
+    "vendor/phpunit",
+    "vendor/psalm",
+    "vendor/rector",
+    "vendor/sebastian",
+    "vendor/squizlabs",
+    "vendor/theseer",
+    "vendor/vimeo",
+    "vendor/webmozart"
+  ],
   "output": "cadfael.phar"
 }


### PR DESCRIPTION
The auto detect that supposed to exclude `require-dev` isn't working as intended so I added some explicit blacklists.

I'll need to poke this some more to see if I can get the size down further.