### PR TITLE
IndexPrefx shouldn't care about unique indexes.

### DIFF
--- a/src/Engine/Check/Index/IndexPrefix.php
+++ b/src/Engine/Check/Index/IndexPrefix.php
@@ -17,6 +17,15 @@ class IndexPrefix implements Check
 
     public function run($entity): ?Report
     {
+        // We can ignore unique indexes since they will always have a cardinality of 1
+        if ($entity->isUnique()) {
+            return new Report(
+                $this,
+                $entity,
+                Report::STATUS_OK
+            );
+        }
+
         // Get all the parts of the index that are a string type
         $string_parts = array_filter($entity->getStatistics(), function ($statistics) {
             return $statistics->column->isPrefixAllowed();

--- a/src/Engine/Check/Index/LowCardinality.php
+++ b/src/Engine/Check/Index/LowCardinality.php
@@ -51,7 +51,7 @@ class LowCardinality implements Check
         // The closer to 1 this value is, the more unique it is.
         // The larger it is, the less unique the results are.
         $messages = [
-            "The ratio of cardinality for this index is $ratio (lower is better).",
+            "The ratio of cardinality for this index is " . number_format($ratio) ." (lower is better).",
             "It is calculated by dividing the table size by column cardinality."
         ];
         $status = Report::STATUS_OK;

--- a/src/Engine/Check/Table/SaneInnoDbPrimaryKey.php
+++ b/src/Engine/Check/Table/SaneInnoDbPrimaryKey.php
@@ -47,7 +47,7 @@ class SaneInnoDbPrimaryKey implements Check
             );
         }
 
-        // If these is, lets work out if it's more space efficient to create a UNIQUE
+        // If there is, lets work out if it's more space efficient to create a UNIQUE
         // KEY of the PRIMARY KEY and add an AUTO_INCREMENT field (4 bytes) instead.
         $current_cost = $primary_key_size + ($index_count * $primary_key_size);
         $unique_key_cost = 4 + ($primary_key_size + 4) + ($index_count * 4);


### PR DESCRIPTION
We shoudn't recommend that unique index constraints use index prefixing.