### PR TITLE
Added UUID Storage check

### DIFF
--- a/src/Cli/Command/RunCommand.php
+++ b/src/Cli/Command/RunCommand.php
@@ -9,6 +9,7 @@ use Cadfael\Engine\Check\Account\NotProperlyClosingConnections;
 use Cadfael\Engine\Check\Column\CorrectUtf8Encoding;
 use Cadfael\Engine\Check\Column\ReservedKeywords;
 use Cadfael\Engine\Check\Column\SaneAutoIncrement;
+use Cadfael\Engine\Check\Column\UUIDStorage;
 use Cadfael\Engine\Check\Index\IndexPrefix;
 use Cadfael\Engine\Check\Index\LowCardinality;
 use Cadfael\Engine\Check\Query\Inefficient;
@@ -125,7 +126,8 @@ class RunCommand extends AbstractDatabaseCommand
             new UnsupportedVersion(),
             new RequirePrimaryKey(),
             new LowCardinality(),
-            new IndexPrefix()
+            new IndexPrefix(),
+            new UUIDStorage()
         );
 
         $load_performance_schema = $input->getOption('performance_schema');

--- a/src/Engine/Check/Column/UUIDStorage.php
+++ b/src/Engine/Check/Column/UUIDStorage.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Cadfael\Engine\Check\Column;
+
+use Cadfael\Engine\Check;
+use Cadfael\Engine\Entity\Column;
+use Cadfael\Engine\Report;
+
+class UUIDStorage implements Check
+{
+    public function supports($entity): bool
+    {
+        // This check should only run on columns
+        return $entity instanceof Column;
+    }
+
+    public function run($entity): ?Report
+    {
+        // We can try to detect if a column is a UUID (E.g.: 8f2cda13-357f-11ec-a9d6-4827ea22e92c) based on:
+        // - Type: [VAR]CHAR(34|36) or [VAR]BINARY(16)
+        // - Name: (contains UUID or ID)
+        $length = $entity->information_schema->character_maximum_length;
+        $is_binary = $entity->isBinary() && $length === 16;
+        $is_string_of_appropriate_length = $entity->isString()
+            && ($length === 34 || $length === 36);
+        $is_type_match = $is_binary || $is_string_of_appropriate_length;
+
+        $is_name_match = stripos($entity->getName(), 'id') !== false
+            || stripos($entity->getName(), 'uuid') !== false;
+
+        // If we don't suspect this field of being a UUID, we can just skip any report
+        if (!$is_name_match || !$is_type_match) {
+            return null;
+        }
+
+        if ($is_binary) {
+            return new Report(
+                $this,
+                $entity,
+                Report::STATUS_OK
+            );
+        } else {
+            return new Report(
+                $this,
+                $entity,
+                Report::STATUS_CONCERN,
+                [
+                    'You are storing a UUID in a string field type. Instead you should use BINARY(16)',
+                    'If you are concerned about ordering, consider exploring UUIDv6, 7 or 8.'
+                ]
+            );
+        }
+    }
+
+    public function getReferenceUri(): string
+    {
+        return 'https://github.com/xsist10/cadfael/wiki/UUID-Storage';
+    }
+
+    public function getName(): string
+    {
+        return 'UUID Storage';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Verify that a column storing UUIDs is correctly structured.';
+    }
+}

--- a/src/Engine/Entity/Column.php
+++ b/src/Engine/Entity/Column.php
@@ -87,6 +87,17 @@ class Column implements Entity
             || in_array($this->information_schema->data_type, [ 'bit', 'decimal', 'double', 'float' ]);
     }
 
+    public function isString(): bool
+    {
+        $string_types = [ 'char', 'longtext', 'mediumtext', 'text', 'tinytext', 'varchar' ];
+        return in_array($this->information_schema->data_type, $string_types);
+    }
+
+    public function isBinary(): bool
+    {
+        return in_array($this->information_schema->data_type, ['binary', 'varbinary']);
+    }
+
     public function isPrefixAllowed(): bool
     {
         return in_array($this->information_schema->data_type, InformationSchema::PREFIX_ALLOWED_DATA_TYPES);

--- a/tests/Engine/Check/Column/UUIDStorageTest.php
+++ b/tests/Engine/Check/Column/UUIDStorageTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Cadfael\Tests\Engine\Check\Column;
+
+use Cadfael\Engine\Report;
+use Cadfael\Tests\Engine\Check\BaseTest;
+use Cadfael\Tests\Engine\Check\ColumnBuilder;
+use Cadfael\Engine\Check\Column\UUIDStorage;
+
+class UUIDStorageTest extends BaseTest
+{
+    protected $non_uuid_string_column;
+    protected $non_uuid_binary_column;
+    protected $uuid_binary_column;
+    protected $uuid_string_column;
+
+    public function setUp(): void
+    {
+        $builder = new ColumnBuilder();
+        $this->non_uuid_string_column = $builder->name("generic_string_column")
+            ->varchar(36)
+            ->generate();
+        $this->non_uuid_string_column->setTable($this->createTable());
+
+        $this->non_uuid_binary_column = $builder->name("generic_binary_column")
+            ->binary(16)
+            ->generate();
+        $this->non_uuid_binary_column->setTable($this->createTable());
+
+        $this->uuid_string_column = $builder->name("uuid_string_column")
+            ->varchar(36)
+            ->generate();
+        $this->uuid_string_column->setTable($this->createTable());
+
+        $this->uuid_binary_column = $builder->name("uuid_binary_column")
+            ->binary(16)
+            ->generate();
+        $this->uuid_binary_column->setTable($this->createTable());
+    }
+
+    public function testSupports()
+    {
+        $check = new UUIDStorage();
+
+        $this->assertTrue($check->supports($this->non_uuid_string_column));
+        $this->assertTrue($check->supports($this->non_uuid_binary_column));
+        $this->assertTrue($check->supports($this->uuid_string_column));
+        $this->assertTrue($check->supports($this->uuid_binary_column));
+    }
+
+    public function testRun()
+    {
+        $check = new UUIDStorage();
+        $this->assertNull($check->run($this->non_uuid_string_column));
+        $this->assertNull($check->run($this->non_uuid_binary_column));
+        $this->assertEquals(Report::STATUS_CONCERN, $check->run($this->uuid_string_column)->getStatus());
+        $this->assertEquals(Report::STATUS_OK, $check->run($this->uuid_binary_column)->getStatus());
+    }
+}

--- a/tests/Engine/Check/ColumnBuilder.php
+++ b/tests/Engine/Check/ColumnBuilder.php
@@ -77,12 +77,22 @@ class ColumnBuilder
         return $this;
     }
 
+    private function lengthType(string $type, int $length): ColumnBuilder
+    {
+        $this->override["DATA_TYPE"] = $type;
+        $this->override["CHARACTER_MAXIMUM_LENGTH"] = $length;
+        $this->override["COLUMN_TYPE"] = "$type($length)";
+        return $this;
+    }
+
+    public function binary(int $length = 10): ColumnBuilder
+    {
+        return $this->lengthType('binary', $length);
+    }
+
     public function varchar(int $length = 10): ColumnBuilder
     {
-        $this->override["DATA_TYPE"] = "varchar";
-        $this->override["CHARACTER_MAXIMUM_LENGTH"] = $length;
-        $this->override["COLUMN_TYPE"] = "varchar($length)";
-        return $this;
+        return $this->lengthType('varchar', $length);
     }
 
     public function generated(): ColumnBuilder


### PR DESCRIPTION
Added check for issue #14 to identify if a sub-optimal storage setup
was being used for UUID fields.

https://github.com/xsist10/cadfael/wiki/UUID-Storage

This is a little hacky as we examine the name of the column to make
a determination if it is actually a UUID field along with the type
and length.