### PR TITLE
Undefined array key "no_quotes"

### DIFF
--- a/src/Engine/Entity/Query.php
+++ b/src/Engine/Entity/Query.php
@@ -134,6 +134,11 @@ class Query implements Entity
 
         $response = [];
         foreach ($parsed['FROM'] as $from) {
+            // It's possible that the FROM is a sub-query. We'll need to deal with this soon
+            if (!isset($from['no_quotes'])) {
+                throw new \Exception("Sub-queries not handled at the moment.");
+            }
+
             // DIGEST should always contain the `schema`.`table`
             $parts = $from['no_quotes']['parts'];
             $table = [];


### PR DESCRIPTION
Issue #70 - To avoid the code dying hard, deal with query parsing situations where a sub-query exists. For now, skip processing this query. This will need to be fixed later.