### PR TITLE
More environmental options

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     container_name: database
     environment:
       # Set an insecure password
+      MYSQL_HOST: 'localhost'
       MYSQL_ROOT_PASSWORD: 'abc123'
       MYSQL_DATABASE: 'test'
       MYSQL_USER: 'user'
@@ -17,6 +18,7 @@ services:
   app:
     container_name: app
     environment:
+      MYSQL_HOST: 'database'
       MYSQL_DATABASE: 'test'
       MYSQL_USER: 'root'
       MYSQL_PASSWORD: 'abc123'

--- a/src/Cli/Command/AbstractDatabaseCommand.php
+++ b/src/Cli/Command/AbstractDatabaseCommand.php
@@ -32,6 +32,28 @@ abstract class AbstractDatabaseCommand extends Command
             : $_SERVER['MYSQL_USER'] ?? 'root';
     }
 
+    /**
+     * @param InputInterface $input
+     * @return mixed|string
+     */
+    public function getHost(InputInterface $input)
+    {
+        return $input->getOption('host')
+            ? $input->getOption('host')
+            : $_SERVER['MYSQL_HOST'] ?? 'localhost';
+    }
+
+    /**
+     * @param InputInterface $input
+     * @return mixed|string
+     */
+    public function getPort(InputInterface $input)
+    {
+        return $input->getOption('port')
+            ? $input->getOption('port')
+            : $_SERVER['MYSQL_PORT'] ?? 3306;
+    }
+
     protected function configure(): void
     {
         $this
@@ -60,8 +82,8 @@ abstract class AbstractDatabaseCommand extends Command
     {
         $this->formatter->write(sprintf(
             "<info>Host:</info> %s:%s",
-            $input->getOption('host'),
-            $input->getOption('port')
+            $this->getHost($input),
+            $this->getPort($input)
         ))->eol();
         $this->formatter->write('<info>User:</info> ' . $this->getUsername($input))->eol();
         $this->formatter->eol();
@@ -109,7 +131,7 @@ abstract class AbstractDatabaseCommand extends Command
             'dbname' => $schemaName,
             'user' => $username,
             'password' => $password,
-            'host' => $input->getOption('host') . ':' . $input->getOption('port'),
+            'host' => $this->getHost($input) . ':' . $this->getPort($input),
             'driver' => 'pdo_mysql',
         );
         $connection = DriverManager::getConnection($connectionParams);

--- a/src/Cli/Command/RunCommand.php
+++ b/src/Cli/Command/RunCommand.php
@@ -62,7 +62,8 @@ class RunCommand extends AbstractDatabaseCommand
                 'performance_schema',
                 'ps',
                 InputOption::VALUE_NONE,
-                'Include performance_schema metric checks. Only useful if the database has been running for a while.'
+                'Include performance_schema metric checks. Only useful if the database has been running for '
+                . 'a while.'
             )
             ->addOption(
                 'output-format',
@@ -75,7 +76,8 @@ class RunCommand extends AbstractDatabaseCommand
                 'force-yes',
                 'f',
                 InputOption::VALUE_NONE,
-                'Force yes on all prompts (like warnings around server not being active for long enough for performance checks to have meaning'
+                'Force yes on all prompts (like warnings around server not being active for long enough for '
+                . 'performance checks to have meaning'
             )
             // the full command description shown when running the command with
             // the "--help" option

--- a/src/Cli/Command/RunCommand.php
+++ b/src/Cli/Command/RunCommand.php
@@ -71,10 +71,18 @@ class RunCommand extends AbstractDatabaseCommand
                 'Changes the output format (json or cli)',
                 'cli'
             )
+            ->addOption(
+                'force-yes',
+                'f',
+                InputOption::VALUE_NONE,
+                'Force yes on all prompts (like warnings around server not being active for long enough for performance checks to have meaning'
+            )
             // the full command description shown when running the command with
             // the "--help" option
             ->setHelp(
                 "You can set the following environment variables:\n" .
+                "* MYSQL_HOST\n" .
+                "* MYSQL_PORT\n" .
                 "* MYSQL_DATABASE\n" .
                 "* MYSQL_USER\n" .
                 "* MYSQL_PASSWORD\n"
@@ -199,13 +207,16 @@ class RunCommand extends AbstractDatabaseCommand
                     ->eol();
                 $this->formatter->write('<comment>Certain checks may be incomplete or misleading.</comment>')->eol();
 
-                $question = new ConfirmationQuestion(
-                    'Run with performance schema checks anyway [Y/N]? ',
-                    false
-                );
+                // If we're not forcing yes, ask if they really want to include these checks
+                if (!$input->getOption('force-yes')) {
+                    $question = new ConfirmationQuestion(
+                        'Run with performance schema checks anyway [Y/N]? ',
+                        false
+                    );
 
-                $helper = $this->getHelper('question');
-                $load_performance_schema = $helper->ask($input, $output, $question);
+                    $helper = $this->getHelper('question');
+                    $load_performance_schema = $helper->ask($input, $output, $question);
+                }
             }
         }
 


### PR DESCRIPTION
MYSQL_HOST and MYSQL_PORT are now settable environmental variables.

Also --force-yes will ensure that any questions that require a y/n
response will automatically select y (for CI/CD pipelines).