### PR TITLE
User can set reporting level

### DIFF
--- a/src/Cli/Formatter.php
+++ b/src/Cli/Formatter.php
@@ -3,6 +3,7 @@
 namespace Cadfael\Cli;
 
 use Cadfael\Engine\Orchestrator;
+use Cadfael\Engine\Report;
 use Symfony\Component\Console\Output\OutputInterface;
 
 abstract class Formatter
@@ -40,7 +41,12 @@ abstract class Formatter
      */
     abstract public function error(string $messages): Formatter;
 
-    abstract public function renderGroupedReports(array $grouped);
+    /**
+     * @param int $severity
+     * @param Report[] $reports
+     * @return Formatter
+     */
+    abstract public function renderReports(int $severity, array $reports);
 
     abstract public function prepareCallback(Orchestrator $orchestrator);
 }

--- a/src/Cli/Formatter/Json.php
+++ b/src/Cli/Formatter/Json.php
@@ -54,17 +54,7 @@ class Json extends Formatter
         return $this;
     }
 
-    public function renderGroupedReports(array $grouped)
-    {
-        $response = [];
-        foreach ($grouped as $reports) {
-            $response[] = $this->renderReports($reports);
-        }
-
-        $this->output->write(json_encode($response));
-    }
-
-    protected function renderReports(array $reports)
+    public function renderReports(int $severity, array $reports)
     {
         $check = $reports[0]->getCheck();
         $response = [
@@ -85,7 +75,8 @@ class Json extends Formatter
             ];
         }
 
-        return $response;
+        $this->output->write(json_encode($response));
+        return $this;
     }
 
     public function prepareCallback(Orchestrator $orchestrator)

--- a/src/Engine/Report.php
+++ b/src/Engine/Report.php
@@ -66,9 +66,14 @@ class Report
         return $this->status;
     }
 
+    public static function getStatusLabelFromValue(int $status): string
+    {
+        return self::STATUS_LABEL[$status];
+    }
+
     public function getStatusLabel(): string
     {
-        return self::STATUS_LABEL[$this->status];
+        return self::getStatusLabelFromValue($this->getStatus());
     }
 
     public function getCheck(): Check


### PR DESCRIPTION
By using the `--severity [1-5]` the user can indicate what level of issues to report on (`1 - all`, `5 - only the most severe`).

Thus this can be used to ensure the user isn't overwhelmed with feedback and allow the user to customize their level of failure for CI jobs.

Related to issues #79 and #41.