### PR TITLE
Automate the version detection

### DIFF
--- a/bin/cadfael
+++ b/bin/cadfael
@@ -10,12 +10,19 @@ foreach ([__DIR__ . '/../../../autoload.php', __DIR__ . '/../vendor/autoload.php
 }
 
 use Symfony\Component\Console\Application;
+use Composer\InstalledVersions as InstalledVersionsAlias;
 use Cadfael\Cli\Command\RunCommand;
 use Cadfael\Cli\Command\AboutCommand;
 
+$version = InstalledVersionsAlias::getPrettyVersion('cadfael/cadfael');
+// Swap out version for git tag if we're dealing with a phar generated with box
+if ($version === 'dev-master' && (int)'@is_phar@') {
+    $version = '@git_tag@';
+}
+
 $application = new Application();
 $application->setName('Cadfael CLI');
-$application->setVersion('0.2.6');
+$application->setVersion($version);
 $application->add(new AboutCommand());
 $application->add(new RunCommand());
 $application->run();

--- a/box.json
+++ b/box.json
@@ -22,5 +22,9 @@
     "vendor/vimeo",
     "vendor/webmozart"
   ],
-  "output": "cadfael.phar"
+  "output": "cadfael.phar",
+  "git": "git_tag",
+  "replacements": {
+    "is_phar": "1"
+  }
 }


### PR DESCRIPTION
To avoid mistakes like accidentally forgetting to manually update the version of cadfeal, this uses `Composer\InstalledVersions` and box's @git_tag@ replacement to fill in the version automatically.