### PR TITLE
Locked accounts

### DIFF
--- a/resources/mysql/sample.sql
+++ b/resources/mysql/sample.sql
@@ -83,3 +83,6 @@ FROM cte;
 
 # Create a passwordless account
 CREATE USER IF NOT EXISTS 'localhost_passwordless_user'@'localhost';
+
+# Create a locked account
+CREATE USER IF NOT EXISTS 'locked_account'@'localhost' IDENTIFIED BY RANDOM PASSWORD ACCOUNT LOCK;

--- a/src/Cli/Command/RunCommand.php
+++ b/src/Cli/Command/RunCommand.php
@@ -6,6 +6,7 @@ namespace Cadfael\Cli\Command;
 
 use Cadfael\Cli\Formatter\Cli;
 use Cadfael\Cli\Formatter\Json;
+use Cadfael\Engine\Check\Account\LockedAccount;
 use Cadfael\Engine\Check\Account\NotConnecting;
 use Cadfael\Engine\Check\Account\NotProperlyClosingConnections;
 use Cadfael\Engine\Check\Account\OutdatedAuthenticationMethod;
@@ -170,6 +171,7 @@ class RunCommand extends AbstractDatabaseCommand
             new LowCardinalityExpensiveStorage(),
             new PasswordlessAccount(),
             new OutdatedAuthenticationMethod(),
+            new LockedAccount(),
         );
 
         if ($load_performance_schema) {

--- a/src/Engine/Check/Account/LockedAccount.php
+++ b/src/Engine/Check/Account/LockedAccount.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cadfael\Engine\Check\Account;
+
+use Cadfael\Engine\Check;
+use Cadfael\Engine\Entity\Account;
+use Cadfael\Engine\Report;
+
+class LockedAccount implements Check
+{
+    public function supports($entity): bool
+    {
+        return $entity instanceof Account;
+    }
+
+    public function run($entity): ?Report
+    {
+        return new Report(
+            $this,
+            $entity,
+            $entity->getUser()->account_locked ? Report::STATUS_INFO : Report::STATUS_OK
+        );
+    }
+
+    /**
+     * @codeCoverageIgnore
+     */
+    public function getReferenceUri(): string
+    {
+        return 'https://github.com/xsist10/cadfael/wiki/Locked-Account';
+    }
+
+    /**
+     * @codeCoverageIgnore
+     */
+    public function getName(): string
+    {
+        return 'Locked Account';
+    }
+
+    /**
+     * @codeCoverageIgnore
+     */
+    public function getDescription(): string
+    {
+        return "Accounts that are locked and may need a cleanup.";
+    }
+}

--- a/src/Engine/Check/Table/EmptyTable.php
+++ b/src/Engine/Check/Table/EmptyTable.php
@@ -41,7 +41,7 @@ class EmptyTable implements Check
             return new Report(
                 $this,
                 $entity,
-                Report::STATUS_CONCERN,
+                Report::STATUS_INFO,
                 [
                     "Table is empty but previously had records inserted.",
                     "It is possible it is used as a some form of queue or has had all records deleted."
@@ -66,7 +66,7 @@ class EmptyTable implements Check
             return new Report(
                 $this,
                 $entity,
-                Report::STATUS_CONCERN,
+                Report::STATUS_INFO,
                 $messages
             );
         }
@@ -74,7 +74,7 @@ class EmptyTable implements Check
         return new Report(
             $this,
             $entity,
-            Report::STATUS_WARNING,
+            Report::STATUS_INFO,
             [ "Table contains no records." ]
         );
     }

--- a/tests/Engine/Check/Account/LockedAccountTest.php
+++ b/tests/Engine/Check/Account/LockedAccountTest.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+namespace Cadfael\Tests\Engine\Check\Account;
+
+use Cadfael\Engine\Check\Account\LockedAccount;
+use Cadfael\Engine\Entity\Account;
+use Cadfael\Engine\Entity\Account\User;
+use Cadfael\Engine\Report;
+use Cadfael\Tests\Engine\BaseTest;
+
+class LockedAccountTest extends BaseTest
+{
+    public function testRun()
+    {
+        $check = new LockedAccount();
+
+        $account = Account::withUser(new User("test", "localhost", account_locked: false));
+
+        $this->assertTrue(
+            $check->supports($account),
+            "Ensure that we care about all accounts."
+        );
+
+        $this->assertEquals(
+            Report::STATUS_OK,
+            $check->run($account)->getStatus(),
+            "Unlocked account is fine."
+        );
+
+        $account = Account::withUser(new User("test", "localhost", account_locked: true));
+
+        $this->assertTrue(
+            $check->supports($account),
+            "Ensure that we care about all accounts."
+        );
+
+        $this->assertEquals(
+            Report::STATUS_INFO,
+            $check->run($account)->getStatus(),
+            "Locked account is informed on."
+        );
+    }
+}

--- a/tests/Engine/Check/Table/EmptyTableTest.php
+++ b/tests/Engine/Check/Table/EmptyTableTest.php
@@ -68,12 +68,12 @@ class EmptyTableTest extends BaseTest
         return [
             [
                 $table,
-                Report::STATUS_WARNING,
+                Report::STATUS_INFO,
                 [ 'Table contains no records.' ]
             ],
             [
                 $table_with_inserts,
-                Report::STATUS_CONCERN,
+                Report::STATUS_INFO,
                 [
                     "Table is empty but previously had records inserted.",
                     "It is possible it is used as a some form of queue or has had all records deleted."
@@ -81,7 +81,7 @@ class EmptyTableTest extends BaseTest
             ],
             [
                 $table_with_data_free,
-                Report::STATUS_CONCERN,
+                Report::STATUS_INFO,
                 [
                     "Table is empty but has allocated free space.",
                     "It is possible it is used as a some form of queue or has had all records deleted."
@@ -89,7 +89,7 @@ class EmptyTableTest extends BaseTest
             ],
             [
                 $table_with_data_free_in_tablespace,
-                Report::STATUS_CONCERN,
+                Report::STATUS_INFO,
                 [
                     "Table is empty but has allocated free space.",
                     "This table is in a shared tablespace so this doesn't mean much."


### PR DESCRIPTION
Locked accounts should be shown to allow users to identify possible clean-up targets.