### PR TITLE
Fix option shortcode conflict

### DIFF
--- a/src/Cli/Command/RunCommand.php
+++ b/src/Cli/Command/RunCommand.php
@@ -68,7 +68,7 @@ class RunCommand extends AbstractDatabaseCommand
             ->setDescription('Run a collection of checks against a database.')
             ->addOption(
                 'performance_schema',
-                'ps',
+                null,
                 InputOption::VALUE_NONE,
                 'Include performance_schema metric checks. Only useful if the database has been running for '
                 . 'a while.'

--- a/tests/Engine/Check/Database/UnsupportedVersionTest.php
+++ b/tests/Engine/Check/Database/UnsupportedVersionTest.php
@@ -44,7 +44,7 @@ class UnsupportedVersionTest extends BaseTest
             '5.1' => Report::STATUS_CRITICAL,
             '5.5' => Report::STATUS_CRITICAL,
             '5.6' => Report::STATUS_CRITICAL,
-            '5.7' => Report::STATUS_OK,
+            '5.7' => Report::STATUS_WARNING,
             '8.0' => Report::STATUS_OK,
         ];
 


### PR DESCRIPTION
Addresses issues #98

Since there is no nice short code (both `p` and `s` are taken) I think it makes sense to remove it for the moment to avoid unintended behaviour.