### PR TITLE
#110 Ensure innodb_file_per_table is ON

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ phpcs:
 	./vendor/bin/phpcs -sw --standard=PSR2 src
 
 phpunit:
-	./vendor/bin/phpunit
+	XDEBUG_MODE=coverage ./vendor/bin/phpunit
 
 box:
 	box compile

--- a/resources/mysql/sample.sql
+++ b/resources/mysql/sample.sql
@@ -1,3 +1,6 @@
+SET GLOBAL innodb_file_per_table=OFF;
+SET GLOBAL sql_require_primary_key=OFF;
+
 CREATE DATABASE IF NOT EXISTS test;
 USE test;
 

--- a/src/Cli/Command/RunCommand.php
+++ b/src/Cli/Command/RunCommand.php
@@ -15,6 +15,7 @@ use Cadfael\Engine\Check\Column\LowCardinalityExpensiveStorage;
 use Cadfael\Engine\Check\Column\ReservedKeywords;
 use Cadfael\Engine\Check\Column\SaneAutoIncrement;
 use Cadfael\Engine\Check\Column\UUIDStorage;
+use Cadfael\Engine\Check\Database\InnoDbFilePerTable;
 use Cadfael\Engine\Check\Index\IndexPrefix;
 use Cadfael\Engine\Check\Index\LowCardinality;
 use Cadfael\Engine\Check\Query\FunctionsOnIndex;
@@ -217,6 +218,7 @@ class RunCommand extends AbstractDatabaseCommand
             new OutdatedAuthenticationMethod(),
             new LockedAccount(),
             new AccountsWithSuperPermission(),
+            new InnoDbFilePerTable(),
         );
 
         if ($load_performance_schema) {

--- a/src/Engine/Check/Database/InnoDbFilePerTable.php
+++ b/src/Engine/Check/Database/InnoDbFilePerTable.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cadfael\Engine\Check\Database;
+
+use Cadfael\Engine\Check;
+use Cadfael\Engine\Entity\Database;
+use Cadfael\Engine\Report;
+
+/**
+ * Class RequirePrimaryKey
+ * @package Cadfael\Engine\Check\Schema
+ */
+class InnoDbFilePerTable implements Check
+{
+    public function supports($entity): bool
+    {
+        if (!$entity instanceof Database) {
+            return false;
+        }
+        return true;
+    }
+
+    public function run($entity): ?Report
+    {
+        $variables = $entity->getVariables();
+        $opt_name = 'innodb_file_per_table';
+        $require_pk_disabled = (!isset($variables[$opt_name]) || $variables[$opt_name] !== 'ON');
+        if ($require_pk_disabled) {
+            return new Report(
+                $this,
+                $entity,
+                Report::STATUS_CONCERN,
+                [
+                    "You are running MySQL 8.0.13+ (MySQL " . $entity->getVersion() . ")"
+                    .  " without innodb_file_per_table enabled.",
+                    "It is recommended to turn this on.",
+                ]
+            );
+        }
+
+        return new Report(
+            $this,
+            $entity,
+            Report::STATUS_OK,
+            [ "You have innodb_file_per_table enabled." ]
+        );
+    }
+
+    /**
+     * @codeCoverageIgnore
+     */
+    public function getReferenceUri(): string
+    {
+        return 'https://github.com/xsist10/cadfael/wiki/Enable-Innodb-File-Per-Table';
+    }
+
+    /**
+     * @codeCoverageIgnore
+     */
+    public function getName(): string
+    {
+        return 'InnoDB file per Table Configuration';
+    }
+
+    /**
+     * @codeCoverageIgnore
+     */
+    public function getDescription(): string
+    {
+        return 'Ensure each InnoDB table is managed in its own file.';
+    }
+}

--- a/tests/Engine/Check/Database/InnoDbFilePerTableTest.php
+++ b/tests/Engine/Check/Database/InnoDbFilePerTableTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+
+namespace Cadfael\Tests\Engine\Check\Database;
+
+use Cadfael\Engine\Check\Database\InnoDbFilePerTable;
+use Cadfael\Engine\Report;
+use Cadfael\Tests\Engine\BaseTest;
+
+class InnoDbFilePerTableTest extends BaseTest
+{
+    private array $databases;
+
+    public function setUp(): void
+    {
+        $this->databases = [
+            '8.0_NOT_SET' => $this->createDatabase([ 'version' => '8.0.13', 'innodb_file_per_table' => null]),
+            '8.0_OFF' => $this->createDatabase([ 'version' => '8.0.13', 'innodb_file_per_table' => 'OFF' ]),
+            '8.0_ON' => $this->createDatabase([ 'version' => '8.0.13', 'innodb_file_per_table' => 'ON' ])
+        ];
+    }
+
+    public function testSupports()
+    {
+        $check = new InnoDbFilePerTable();
+
+        $this->assertTrue($check->supports($this->databases['8.0_NOT_SET']), "Ensure that we care about all databases.");
+        $this->assertTrue($check->supports($this->databases['8.0_OFF']), "Ensure that we care about all databases.");
+        $this->assertTrue($check->supports($this->databases['8.0_ON']), "Ensure that we care about all databases.");
+        $this->assertFalse($check->supports($this->createTable()), "We only support database entities.");
+    }
+
+    public function testRun()
+    {
+        $check = new InnoDbFilePerTable();
+
+        $this->assertEquals(
+            Report::STATUS_CONCERN,
+            $check->run($this->databases['8.0_NOT_SET'])->getStatus(),
+            "Ensure we return " . Report::STATUS_WARNING . " for all MySQL versions with innodb_file_per_table not set."
+        );
+
+        $this->assertEquals(
+            Report::STATUS_CONCERN,
+            $check->run($this->databases['8.0_OFF'])->getStatus(),
+            "Ensure we return " . Report::STATUS_WARNING . " for MySQL versions with innodb_file_per_table set to OFF."
+        );
+
+        $this->assertEquals(
+            Report::STATUS_OK,
+            $check->run($this->databases['8.0_ON'])->getStatus(),
+            "We are happy if it is enabled."
+        );
+    }
+}


### PR DESCRIPTION
There are a number of benefits to ensuring this is enabled (it is the default since MySQL 5.6) but there may be very specific technical decisions behind the choice to disable it so this is marked as a CONCERN and not a WARNING.